### PR TITLE
Res adjustment

### DIFF
--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -73,8 +73,6 @@ def build_template(*, domain_length, resolution):
 
 def sum_one(da):
     sum_da = da.sum(dim="x").sum(dim="y")
-    norm_ds = da / sum_da
-    cutoff = 0.1 * sum_da
-    output_ds = norm_ds.where(norm_ds > cutoff)
+    output_ds = da / sum_da
     return output_ds
 

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -16,7 +16,7 @@ def rotate_domain(da, *, wind_direction):
 def build_domain(*, domain_length: int, resolution: int, time: np.ndarray):
     x = np.linspace(0, domain_length-resolution, int(domain_length / resolution))
     y = np.linspace(
-        -(domain_length-resolution) / 2, (domain_length -resolution)/ 2, int(domain_length / resolution)
+        -(domain_length) / 2+resolution, (domain_length )/ 2, int(domain_length / resolution)
     )
     xx, yy = np.meshgrid(x, y)
     data = np.zeros(
@@ -64,7 +64,7 @@ def build_template(*, domain_length, resolution):
         -domain_length, domain_length-resolution, (int(domain_length / resolution) * 2)
     )
     template_y = np.linspace(
-        -domain_length, domain_length-resolution, (int(domain_length / resolution) * 2)
+        -domain_length+resolution, domain_length, (int(domain_length / resolution) * 2)
     )
     template_xx, template_yy = np.meshgrid(template_x, template_y, indexing="xy")
     query_points = np.array((template_xx.flatten(), template_yy.flatten())).transpose()

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -14,9 +14,9 @@ def rotate_domain(da, *, wind_direction):
 
 
 def build_domain(*, domain_length: int, resolution: int, time: np.ndarray):
-    x = np.linspace(0, domain_length, int(domain_length / resolution+1))
+    x = np.linspace(0, domain_length-resolution, int(domain_length / resolution))
     y = np.linspace(
-        -domain_length / 2, domain_length / 2, int(domain_length / resolution+1)
+        -(domain_length-resolution) / 2, (domain_length -resolution)/ 2, int(domain_length / resolution)
     )
     xx, yy = np.meshgrid(x, y)
     data = np.zeros(
@@ -61,10 +61,10 @@ def normalize_domain(
 
 def build_template(*, domain_length, resolution):
     template_x = np.linspace(
-        -domain_length, domain_length, (int(domain_length / resolution) * 2+1)
+        -domain_length, domain_length-resolution, (int(domain_length / resolution) * 2)
     )
     template_y = np.linspace(
-        -domain_length, domain_length, (int(domain_length / resolution) * 2+1)
+        -domain_length, domain_length-resolution, (int(domain_length / resolution) * 2)
     )
     template_xx, template_yy = np.meshgrid(template_x, template_y, indexing="xy")
     query_points = np.array((template_xx.flatten(), template_yy.flatten())).transpose()

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -14,9 +14,9 @@ def rotate_domain(da, *, wind_direction):
 
 
 def build_domain(*, domain_length: int, resolution: int, time: np.ndarray):
-    x = np.linspace(0, domain_length, int(domain_length / resolution))
+    x = np.linspace(0, domain_length, int(domain_length / resolution+1))
     y = np.linspace(
-        -domain_length / 2, domain_length / 2, int(domain_length / resolution)
+        -domain_length / 2, domain_length / 2, int(domain_length / resolution+1)
     )
     xx, yy = np.meshgrid(x, y)
     data = np.zeros(
@@ -61,10 +61,10 @@ def normalize_domain(
 
 def build_template(*, domain_length, resolution):
     template_x = np.linspace(
-        -domain_length, domain_length, int(domain_length / resolution) * 2
+        -domain_length, domain_length, int(domain_length / resolution+1) * 2
     )
     template_y = np.linspace(
-        -domain_length, domain_length, int(domain_length / resolution) * 2
+        -domain_length, domain_length, int(domain_length / resolution+1) * 2
     )
     template_xx, template_yy = np.meshgrid(template_x, template_y, indexing="xy")
     query_points = np.array((template_xx.flatten(), template_yy.flatten())).transpose()

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -61,10 +61,10 @@ def normalize_domain(
 
 def build_template(*, domain_length, resolution):
     template_x = np.linspace(
-        -domain_length, domain_length, int(domain_length / resolution+1) * 2
+        -domain_length, domain_length, (int(domain_length / resolution) * 2+1)
     )
     template_y = np.linspace(
-        -domain_length, domain_length, int(domain_length / resolution+1) * 2
+        -domain_length, domain_length, (int(domain_length / resolution) * 2+1)
     )
     template_xx, template_yy = np.meshgrid(template_x, template_y, indexing="xy")
     query_points = np.array((template_xx.flatten(), template_yy.flatten())).transpose()

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -74,7 +74,7 @@ def build_template(*, domain_length, resolution):
 def sum_one(da):
     sum_da = da.sum(dim="x").sum(dim="y")
     norm_ds = da / sum_da
-    cutoff = 0.01 * sum_da
+    cutoff = 0.1 * sum_da
     output_ds = norm_ds.where(norm_ds > cutoff)
     return output_ds
 

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -73,6 +73,8 @@ def build_template(*, domain_length, resolution):
 
 def sum_one(da):
     sum_da = da.sum(dim="x").sum(dim="y")
-    output_ds = da / sum_da
+    norm_ds = da / sum_da
+    cutoff = 0.001 * sum_da
+    output_ds = norm_ds.where(norm_ds > cutoff)
     return output_ds
 

--- a/eddy_footprint/spatial.py
+++ b/eddy_footprint/spatial.py
@@ -74,7 +74,7 @@ def build_template(*, domain_length, resolution):
 def sum_one(da):
     sum_da = da.sum(dim="x").sum(dim="y")
     norm_ds = da / sum_da
-    cutoff = 0.001 * sum_da
+    cutoff = 0.01 * sum_da
     output_ds = norm_ds.where(norm_ds > cutoff)
     return output_ds
 


### PR DESCRIPTION
Slight adjustment to the domain so that the resulting resolution of footprint stacks (after rotation) always have the exact x and y resolution as was provided in the input argument. The other consequence of this change is the domain extent is now -domain length to + (domain length - resolution). So if the domain length is 500 and resolution is 2.5 meters, the extent will be from -500 to 497.5 meters exactly 2.5 m apart in x dimension, and -497.5 to 500 m in the y dimension. This aligns with the convention of coordinates representing the upper left corner of grid cells.